### PR TITLE
Use URLs with distinct last path components

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "PSPDFKit",
-            url: "https://customers.pspdfkit.com/pspdfkit/xcframework/11.3.1.zip",
+            url: "https://customers.pspdfkit.com/pspdfkit-xcframework-11.3.1.zip",
             checksum: "8b72c61db0497111cb5e94af2269c8e8a5a7b5935f5600d87264e1df266f0144"),
         .binaryTarget(
             name: "PSPDFKitUI",
-            url: "https://customers.pspdfkit.com/pspdfkitui/xcframework/11.3.1.zip",
+            url: "https://customers.pspdfkit.com/pspdfkitui-xcframework-11.3.1.zip",
             checksum: "d2ba1b1a01ac5a4cb36610200f8e13e671d8608608a6dcde46721e9b0ab04ab1"),
     ]
 )


### PR DESCRIPTION
We’ve noticed that since Xcode 13.0 fresh clones of our sample apps fail to download the binaries from the PSPDFKit Swift package until you manually Reset Package Caches. Usually you would see this error:

`failed downloading 'https://customers.pspdfkit.com/pspdfkit/xcframework/11.3.1.zip' which is required by binary target 'PSPDFKit': ~/Library/Developer/Xcode/DerivedData/Minimal-enhpcflwoobkdifztstuqbqotegx/SourcePackages/artifacts/pspdfkit-sp/11.3.1.zip already exists in file system`

Sometimes this one instead (PSPDFKitUI instead of PSPDFKit):

`failed downloading 'https://customers.pspdfkit.com/pspdfkitui/xcframework/11.3.1.zip' which is required by binary target 'PSPDFKitUI': ~/Library/Developer/Xcode/DerivedData/Minimal-enhpcflwoobkdifztstuqbqotegx/SourcePackages/artifacts/pspdfkit-sp/11.3.1.zip already exists in file system`

It looks like on this particular package checkout code path, Xcode/SwiftPM ignores the suggested filenames from the HTTP headers and instead uses the last path component of the URL as the filename for the download, which was `11.3.1.zip` for both PSPDFKit and PSPDFKitUI. It tries to put the binaries for PSPDFKit and PSPDFKitUI in the same directory, so whichever of these downloads finished last will fail (usually PSPDFKit because it’s a larger file).

This PR works around the Xcode/SwiftPM issue by using URLs with distinct last path components.