### PR TITLE
Remove listing compatible iOS and Xcode version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ at the [PSPDFKit Guides](https://pspdfkit.com/guides/ios/current/).
 
 PSPDFKit comes with two dynamic frameworks, the model layer (PSPDFKit.xcframework) and the UI layer (PSPDFKitUI.xcframework), and optional CocoaPods and Carthage support for easy integration.
 
+See [System Compatibility for iOS](https://pspdfkit.com/guides/ios/announcements/version-support/) for more information on supported operating systems.
+
 ## Support
 
 For questions or to report issues, open a ticket on our [support platform](https://pspdfkit.com/support/request).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ To get started with PSPDFKit we suggest reading the [Integrating PSPDFKit](https
 at the [PSPDFKit Guides](https://pspdfkit.com/guides/ios/current/).
 
 PSPDFKit comes with two dynamic frameworks, the model layer (PSPDFKit.xcframework) and the UI layer (PSPDFKitUI.xcframework), and optional CocoaPods and Carthage support for easy integration.
-PSPDFKit is compatible with iOS 13, 14, and 15 and Xcode 13+.
 
 ## Support
 


### PR DESCRIPTION
This PR removes listing the compatible iOS and Xcode version of PSPDFKit, as those are seen in the guides as well.