### PR TITLE
Update Swift Package binary URLs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,11 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "PSPDFKit",
-            url: "https://customers.pspdfkit.com/pspdfkit-xcframework-26.6.0.zip",
+            url: "https://my.nutrient.io/pspdfkit-xcframework-26.6.0.zip",
             checksum: "070b5ca0745b49845d4e0a788e37510a2826f7d2a91ee8af4cd8ede5ddd1f4f6"),
         .binaryTarget(
             name: "PSPDFKitUI",
-            url: "https://customers.pspdfkit.com/pspdfkitui-xcframework-26.6.0.zip",
+            url: "https://my.nutrient.io/pspdfkitui-xcframework-26.6.0.zip",
             checksum: "5357e81f4a5f57ac632b2115bf44a2dbbc61db73f5a01127bcd38303bbefbffa"),
     ]
 )


### PR DESCRIPTION
## Summary
This updates the Swift package manifest to use `my.nutrient.io` for the published binary
